### PR TITLE
Use the correct lib filename on darwin.

### DIFF
--- a/src/charms.lisp
+++ b/src/charms.lisp
@@ -39,7 +39,8 @@
 
 #-sb-unicode
 (define-foreign-library libcurses
-    (:unix (:or "libcurses.so" "libncurses.so"))
+  (:darwin (:or "libcurses.dylib" "libncurses.dylib"))
+  (:unix (:or "libcurses.so" "libncurses.so"))
   (t (:default "libcurses")))
    
 (use-foreign-library libcurses)


### PR DESCRIPTION
The dynamic linker on darwin was trying to load "libcurses.so", which doesn't work since on darwin it is called "libcurses.dylib". Added a case for darwin so that it uses the correct filenames.
