### PR TITLE
Use correct soname (incl. major version) on unix

### DIFF
--- a/src/charms.lisp
+++ b/src/charms.lisp
@@ -29,18 +29,17 @@
 ;;;; TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 ;;;; SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
 (cl:in-package :cl-charms)
 
 #+sb-unicode
 (define-foreign-library libcurses
-    (:unix "libncursesw.so")
+    (:unix "libncursesw.so.5")
   (t (:default "libcurses")))
 
 #-sb-unicode
 (define-foreign-library libcurses
   (:darwin (:or "libcurses.dylib" "libncurses.dylib"))
-  (:unix (:or "libcurses.so" "libncurses.so"))
+  (:unix (:or "libncurses.so.5" "libcurses"))
   (t (:default "libcurses")))
    
 (use-foreign-library libcurses)


### PR DESCRIPTION
On recent Debian/Ubuntu versions, "libncurses.so" is a linker script and thus can't be loaded dynamically because the dynamic linker doesn't know how to handle linker scripts.

When loading libraries at runtime, it is generally recommended to always use the "soname" of a library (i.e. the filename where the major version is appended - "libncurses.so.5") instead of the "linkname" (i.e. the filename with just the ".so" extension" - "ibncurses.so") to avoid such problems.

See also http://lispcaveats.tumblr.com/post/13259176455/ffi-linking-against-shared-libraries and https://blog.flameeyes.eu/2009/10/a-shared-library-by-any-other-name
