### PR TITLE
Fix bool foreign type

### DIFF
--- a/cl-charms.asd
+++ b/cl-charms.asd
@@ -38,11 +38,13 @@
   :license "MIT License (See COPYING)"
   :depends-on (#:cffi
                #:alexandria)
+  :defsystem-depends-on (#:cffi-grovel) ; for processing :cffi-grovel-file
   :serial t
   :pathname "src/"
   :components ((:module "low-level"
                 :serial t
                 :components ((:file "package")
+                             (:cffi-grovel-file "curses-grovel")
                              (:file "curses-bindings")))
                (:module "high-level"
                 :serial t

--- a/src/low-level/curses-bindings.lisp
+++ b/src/low-level/curses-bindings.lisp
@@ -89,7 +89,7 @@
 
 
 ;; types
-(cffi:defctype bool :int)
+;;  note: bool definition is moved into grovel file (curses-grovel.lisp)
 (cffi:defctype char-ptr :pointer)
 (cffi:defctype chtype :int)
 (cffi:defctype file-ptr :pointer)

--- a/src/low-level/curses-grovel.lisp
+++ b/src/low-level/curses-grovel.lisp
@@ -1,0 +1,5 @@
+;; (include "/usr/include/ncurses.h")
+(include "ncurses.h")
+(in-package #:cl-charms/low-level)
+
+(ctype bool "bool") ;; grovel it, because sizeof(bool) is implementation-dependent


### PR DESCRIPTION
charms/ll functions with returning type `bool` (e.g. `has-color`), is corrupted in
some environment (including mine: Mac OS 10.9.5, SBCL 1.2.11, clang-600.0.57).
This is because `sizeof(bool)` is implementation-dependent in C language.

so changed to use cffi-grovel for defining `bool` in binding code.

By the way, I considered to use CFFI's [`:boolean`](https://common-lisp.net/project/cffi/manual/cffi-manual.html#Other-Types) type, so that such functions return
 `t` or `nil` instead of `1` or `0`. The problem is that it affects backward compatibility.