### PR TITLE
Fix bindings for functions taking pointer to chtype.

### DIFF
--- a/src/low-level/curses-bindings.lisp
+++ b/src/low-level/curses-bindings.lisp
@@ -90,6 +90,7 @@
 
 ;;  note: bool & chtype definitions are in the grovel file (curses-grovel.lisp)
 (cffi:defctype char-ptr :pointer)
+(cffi:defctype chstr (:pointer chtype))
 (cffi:defctype file-ptr :pointer)
 (cffi:defctype screen-ptr :pointer)
 (cffi:defctype window-ptr :pointer)
@@ -150,35 +151,35 @@
 ;; addchstr
 (define-exported-cfuns ("addchstr")
     :int
-  (ch chtype))
+  (chstr chstr))
 
 (define-exported-cfuns ("addchnstr")
     :int
-  (ch chtype)
+  (chstr chstr)
   (n :int))
 
 (define-exported-cfuns ("waddchstr")
     :int
   (win window-ptr)
-  (ch chtype))
+  (chstr chstr))
 
 (define-exported-cfuns ("waddchnstr")
     :int
   (win window-ptr)
-  (ch chtype)
+  (chstr chstr)
   (n :int))
 
 (define-exported-cfuns ("mvaddchstr")
     :int
   (y :int)
   (x :int)
-  (ch chtype))
+  (chstr chstr))
 
 (define-exported-cfuns ("mvaddchnstr")
     :int
   (y :int)
   (x :int)
-  (ch chtype)
+  (chstr chstr)
   (n :int))
 
 (define-exported-cfuns ("mvwaddchstr")
@@ -186,14 +187,14 @@
   (win window-ptr)
   (y :int)
   (x :int)
-  (ch chtype))
+  (chstr chstr))
 
 (define-exported-cfuns ("mvwaddchnstr")
     :int
   (win window-ptr)
   (y :int)
   (x :int)
-  (ch chtype)
+  (chstr chstr)
   (n :int))
 
 
@@ -1016,43 +1017,50 @@ value. Replaces primary value (which would be garbage) with :ERROR if C-function
 ;; inchstr
 (define-exported-cfuns ("inchstr")
     :int
-  (chstr char-ptr))
+  (chstr chstr))
 
 (define-exported-cfuns ("inchnstr")
     :int
-  (chstr char-ptr)
+  (chstr chstr)
   (n :int))
 
 (define-exported-cfuns ("winchstr")
     :int
   (win window-ptr)
-  (chstr char-ptr))
+  (chstr chstr))
 
 (define-exported-cfuns ("winchnstr")
     :int
   (win window-ptr)
-  (chstr char-ptr)
+  (chstr chstr)
   (n :int))
 
 (define-exported-cfuns ("mvinchstr")
     :int
   (y :int)
   (x :int)
-  (chstr char-ptr))
+  (chstr chstr))
+
+(define-exported-cfuns ("mvinchnstr")
+    :int
+  (y :int)
+  (x :int)
+  (chstr chstr)
+  (n :int))
 
 (define-exported-cfuns ("mvwinchstr")
     :int
   (win window-ptr)
   (y :int)
   (x :int)
-  (chstr char-ptr))
+  (chstr chstr))
 
 (define-exported-cfuns ("mvwinchnstr")
     :int
   (win window-ptr)
   (y :int)
   (x :int)
-  (chstr char-ptr)
+  (chstr chstr)
   (n :int))
 
 


### PR DESCRIPTION
I noticed while digging in the library that some functions that are supposed to take a `chtype *` are parameterized with `chtype` and, in some cases, `chr-ptr`

This should fix that, And I've had success testing functions that previously failed, for example, `CHARMS/LL:MVWADDCHSTR`
```
(defun write-stringch-at-point (window string x y)
  (check-status
   (let ((octets (babel:string-to-octets string)))
     (cffi:with-foreign-object (arr 'charms/ll::chtype (length octets))
       (loop for octet across octets
             for i from 0
             do (setf (cffi:mem-aref arr 'charms/ll::chtype i) octet))
       (charms/ll:mvwaddchstr (window-pointer (resolve-window window)) y x arr))))
  t)
```
Some C function declarations:
http://invisible-island.net/ncurses/man/curs_addchstr.3x.html