### PR TITLE
Make compile on MS Windows

### DIFF
--- a/src/low-level/curses-bindings.lisp
+++ b/src/low-level/curses-bindings.lisp
@@ -40,7 +40,9 @@
               "libncursesw.so.5"
               "libncursesw.so.14.0"
               "libncursesw.so"))
-  (:windows (:or "pdcurses" "libcurses"))
+  (:windows (:or "libpdcurses"
+		 "pdcurses"
+		 "libcurses"))
   (t (:default "libcurses")))
 
 #-unicode
@@ -56,7 +58,8 @@
               "libncursesw.so.14.0"
               "libncurses.so"
               "libcurses"))
-  (:windows (:or "pdcurses"
+  (:windows (:or "libpdcurses"		;MSYS installed pdcurses
+		 "pdcurses"
                  "libcurses"))
   (t (:default "libcurses")))
 

--- a/src/low-level/curses-grovel.lisp
+++ b/src/low-level/curses-grovel.lisp
@@ -1,5 +1,6 @@
 ;; (include "/usr/include/ncurses.h")
-(include "ncurses.h")
+#-(or windows win32) (include "ncurses.h")
+#+(or windows win32) (include "pdcurses.h")
 
 (in-package #:cl-charms/low-level)
 


### PR DESCRIPTION
Add `libpdcurses` to foreign library definition
Conditionally include `pdcurses.h` if building on MS Windows.

Fixes #58 