### PR TITLE
Improve ncurses library order

### DIFF
--- a/src/low-level/curses-bindings.lisp
+++ b/src/low-level/curses-bindings.lisp
@@ -36,10 +36,15 @@
 #+unicode
 (cffi:define-foreign-library libcurses
   (:darwin (:or "libncurses.dylib" "libcurses.dylib"))
-  (:unix (:or "libncursesw.so.6"
-              "libncursesw.so.5"
+  ;; Unversioned .so files are preferred for portability.
+  ;; Wide-char libraries (libncursesw) are required for Unicode support.
+  (:unix (:or "libncursesw.so"
               "libncursesw.so.14.0"
-              "libncursesw.so"))
+              "libncursesw.so.9"
+              "libncursesw.so.8"
+              "libncursesw.so.6"
+              "libncursesw.so.5"
+              "libcurses"))
   (:windows (:or #-pdcurses "libncursesw6.dll"
                  #+pdcurses "libpdcurses"
                  #+pdcurses "pdcurses"
@@ -50,17 +55,22 @@
 (cffi:define-foreign-library libcurses
   (:darwin (:or "libncurses.dylib"
                 "libcurses.dylib"))
-  (:unix (:or "libncursesw.so.6"        ; XXX: is this the right thing
-                                        ; to load? Should we also add
-                                        ; libncursesw.so as a
-                                        ; fallback?
+  ;; Even with Unicode feature disabled, we fallback to wide-char libraries
+  ;; since they're backwards-compatible.
+  (:unix (:or "libncurses.so"
+              "libncurses.so.9"
+              "libncurses.so.8"
               "libncurses.so.6"
               "libncurses.so.5"
+              "libncursesw.so"
               "libncursesw.so.14.0"
-              "libncurses.so"
+              "libncursesw.so.9"
+              "libncursesw.so.8"
+              "libncursesw.so.6"
+              "libncursesw.so.5"
               "libcurses"))
   (:windows (:or #-pdcurses "libncursesw6.dll"
-                 #+pdcurses "libpdcurses"         ;MSYS installed pdcurses
+                 #+pdcurses "libpdcurses"
                  #+pdcurses "pdcurses"
                  #+pdcurses "libcurses"))
   (t (:default "libcurses")))


### PR DESCRIPTION
Fix build failure on FreeBSD due to missing library file and prefer .so as the system package manager generally handles the symlinks for us.

wide ncurses as fallback as theyre backwards compatible.

This should fix issue #46 and issue #60

I had the following error on FreeBSD.

```
debugger invoked on a CFFI:LOAD-FOREIGN-LIBRARY-ERROR in thread
#<THREAD tid=339373 "main thread" RUNNING {110DB381D3}>:
  Unable to load any of the alternatives:
   ("libncursesw.so.6" "libncursesw.so.5" "libncursesw.so.14.0"
    "libncursesw.so")
```